### PR TITLE
Type: hotfix/unable context menu about untracked directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -55,6 +55,8 @@ app.get("/", async (req, res) => {
   const files = await user.getFilesInCurrentDir();
   user.gitManager.checkIgnores(files, user.path);
 
+  console.log(user.history);
+
   res.render("index", {
     title: "Pretty git, Make Your git usage Fancy",
     files: files,
@@ -121,6 +123,10 @@ app.post("/dirs/git/init", (req, res) => {
 
 app.get("/dirs/git/isRepo", (req, res) => {
   res.send(user.history.isRepo);
+});
+
+app.get("/dirs/git/isTracked", (req, res) => {
+  res.send(user.history.directoryStatus);
 });
 
 app.get("/dirs/git/status", (req, res) => {

--- a/src/public/scripts/directory.js
+++ b/src/public/scripts/directory.js
@@ -13,7 +13,7 @@ let modified = [];
 let staged = [];
 let committed = [];
 
-directories.forEach((dir) => {
+directories.forEach(async (dir) => {
   const imageContainer = dir.querySelector(".file-image-container");
   const imageSrc = imageContainer.querySelector("img").src;
   const statusString = imageSrc.split("/")[4].split(".")[0];
@@ -43,17 +43,18 @@ directories.forEach((dir) => {
   });
 
   //특정 상태에 대해서는 context menu를 띄우지 않음
+  const isTracked = await axios.get("/dirs/git/isTracked");
   if (
     statusString != "ignored" &&
     statusString != "folder" &&
-    statusString != "documents"
+    statusString != "documents" &&
+    isTracked.data != "untracked"
   ) {
     dir.addEventListener("contextmenu", (event) => {
       // 기본 Context Menu가 나오지 않게 차단
       event.preventDefault();
 
       const directoryName = dir.childNodes[2].innerHTML;
-
       const ctxMenu = document.createElement("div");
 
       ctxMenu.id = "context-menu";


### PR DESCRIPTION
Body: 기존에는 untracked 디렉토리 내에서 커맨드를 실행할 수 있도록 했음/
하지만, 그러한 행위는 git에서 지양하는 행위이고 status에도 추적되지 않기 때문에, 상위 디렉토리가 untracked라면 하위 디렉토리에 대한 git command지원 기능을 삭제하였음