### PR TITLE
feat: Feature4(git clone) BE 

### DIFF
--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -276,6 +276,7 @@ const handleCloneRequest = async (req, res, user) => {
 
   try {
     gitHelper.cwd(user.path);
+    
     // clone(repoPath: string, localPath: string, options?: TaskOptions | undefined, callback?: SimpleGitTaskCallback<string> | undefined): Response<string>
     gitHelper.clone(remoteAddress, localAddress);
     res.status(200).json({

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -290,12 +290,11 @@ const handleCloneRequest = async (req, res, user) => {
         },
       };
       await gitHelper.clone(remoteAddress, user.path, authHeader);
-
-
+    } else {
+        // clone(repoPath: string, localPath: string, options?: TaskOptions | undefined, callback?: SimpleGitTaskCallback<string> | undefined): Response<string>
+        gitHelper.clone(remoteAddress, user.path);
     }
 
-    // clone(repoPath: string, localPath: string, options?: TaskOptions | undefined, callback?: SimpleGitTaskCallback<string> | undefined): Response<string>
-    gitHelper.clone(remoteAddress, user.path);
     res.status(200).json({
       type: "success",
       msg: `Successfully clone from '${remoteAddress}'`,

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -279,6 +279,15 @@ const handleCloneRequest = async (req, res, user) => {
   try {
     gitHelper.cwd(user.path);
 
+    const isGitRepo = await gitHelper.checkIsRepo();
+    
+    if (isGitRepo) {
+      res.status(400).json({
+        type: "error",
+        msg: "This directory is already a Git repository. You should clone it other directory."
+      })
+    }
+
     // const repoType = await axios.get(`https://api.github.com/repos/${remoteAddress}`);
     const repoType = await axios.get(remoteAddress);
     const isPrivate = repoType.data.private;

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -271,16 +271,24 @@ const handleMergeRequest = async (req, res, user) => {
 };
 
 const handleCloneRequest = async (req, res, user) => {
+  const remoteAddress = req.body.remoteAddress;
+  const localAddress = req.body.localAddress;
+
   try {
     gitHelper.cwd(user.path);
-    const { remoteAddress } = req.body;
-    await gitHelper.clone([remoteAddress]);
+    // clone(repoPath: string, localPath: string, options?: TaskOptions | undefined, callback?: SimpleGitTaskCallback<string> | undefined): Response<string>
+    gitHelper.clone(remoteAddress, localAddress);
     res.status(200).json({
       type: "success",
       msg: `Successfully clone from '${remoteAddress}'`,
     });
   } catch (error) {
-    console.log(error);
+      console.log(`Error[git clone] :  ${error}`);
+      res.status(500).json({
+          type: "error",
+          msg: `Failed to clone from '${remoteAddress}'`,
+          error: error,
+      });
   }
 };
 

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -10,6 +10,7 @@ import {
 } from "../modules/gitCommand.js";
 //git 명령어를 실행하기 위한 helper library
 import { simpleGit } from "simple-git";
+import axios from "axios";
 const options = {
   baseDir: process.cwd(),
   binary: "git",
@@ -278,12 +279,13 @@ const handleCloneRequest = async (req, res, user) => {
   try {
     gitHelper.cwd(user.path);
 
-    const repoType = await axios.get(`https://api.github.com/repos/${remoteAddress}`);
+    // const repoType = await axios.get(`https://api.github.com/repos/${remoteAddress}`);
+    const repoType = await axios.get(remoteAddress);
     const isPrivate = repoType.data.private;
 
-    if(isPrivate) {
+    if (isPrivate) {
       const { id, token } = req.body;
-      // GithubAPI 인증에 필요한 헤더. 
+      // GithubAPI 인증에 필요한 헤더.
       const authHeader = {
         headers: {
           Authorization: `Bearer ${token}`,
@@ -291,8 +293,8 @@ const handleCloneRequest = async (req, res, user) => {
       };
       await gitHelper.clone(remoteAddress, user.path, authHeader);
     } else {
-        // clone(repoPath: string, localPath: string, options?: TaskOptions | undefined, callback?: SimpleGitTaskCallback<string> | undefined): Response<string>
-        gitHelper.clone(remoteAddress, user.path);
+      // clone(repoPath: string, localPath: string, options?: TaskOptions | undefined, callback?: SimpleGitTaskCallback<string> | undefined): Response<string>
+      gitHelper.clone(remoteAddress, user.path);
     }
 
     res.status(200).json({

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -280,11 +280,11 @@ const handleCloneRequest = async (req, res, user) => {
     gitHelper.cwd(user.path);
 
     const isGitRepo = await gitHelper.checkIsRepo();
-    
+
     if (isGitRepo) {
       res.status(400).json({
         type: "error",
-        msg: "This directory is already a Git repository. You should clone it other directory."
+        msg: "This directory is already a Git repository. You should clone i other directory."
       })
     }
 

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -272,13 +272,12 @@ const handleMergeRequest = async (req, res, user) => {
 
 const handleCloneRequest = async (req, res, user) => {
   const remoteAddress = req.body.remoteAddress;
-  const localAddress = req.body.localAddress;
 
   try {
     gitHelper.cwd(user.path);
-    
+
     // clone(repoPath: string, localPath: string, options?: TaskOptions | undefined, callback?: SimpleGitTaskCallback<string> | undefined): Response<string>
-    gitHelper.clone(remoteAddress, localAddress);
+    gitHelper.clone(remoteAddress, user.path);
     res.status(200).json({
       type: "success",
       msg: `Successfully clone from '${remoteAddress}'`,

--- a/src/modules/gitCommand.js
+++ b/src/modules/gitCommand.js
@@ -1,5 +1,6 @@
 import fs from "fs";
 import { spawn } from "child_process";
+import { resolve } from "path";
 
 const gitInit = (curPath) => {
   return new Promise((resolve, reject) => {
@@ -203,6 +204,13 @@ const gitBranch = (userPath, branchName) => {
     });
   });
 };
+
+const gitClone = (repoPath) => {
+  return new Promise((resolve, reject) => {
+    const args = ["clone", repoPath];
+    const child = spawn("git", args, { cwd})
+  })
+}
 
 export {
   gitAdd,

--- a/src/modules/gitCommand.js
+++ b/src/modules/gitCommand.js
@@ -205,13 +205,6 @@ const gitBranch = (userPath, branchName) => {
   });
 };
 
-const gitClone = (repoPath) => {
-  return new Promise((resolve, reject) => {
-    const args = ["clone", repoPath];
-    const child = spawn("git", args, { cwd})
-  })
-}
-
 export {
   gitAdd,
   gitInit,


### PR DESCRIPTION
# 작업내용
- git clone be 구현.
- private repo의 경우 id, accessToken 받아와서 처리할 수 있도록 함. 

# 리뷰요청
- 현재 local dir 위치에서 clone 해올 수 있도록 제작. 
- repoType이 public일 때 : 
```
{
  "remoteAddress": "https://github.com/filebrowser/filebrowser.git"
}
```
이런 식으로 remoteAddress만 받도록 함. 
- repoType이 private일 때 : 
```
{
  "remoteAddress": "https://github.com/filebrowser/filebrowser.git"
  "id": "devrokket",
  "token": "xxxxxxxxxxxxxxx"
}
```
이런 식으로 id와 token을 받아와야 함. 

# 참고사항
- private repo는 테스트를 진행하지 못 하였음.
- GithubAPI 인증 헤더를 사용하지 않고 isPrivate을 body로 받아서 분기처리 하면 더 확실히 처리가 가능한데 UI적으로 별로일 것 같아서 인증헤더를 사용해봄. 

# 첨부사진
<img width="595" alt="Screen Shot 2023-05-28 at 3 25 40 PM" src="https://github.com/OSS-FILEBROWSER/pretty-git/assets/96538554/ca03b020-8c9b-4918-ba8c-e21dc8cfbc2d">
