### PR TITLE
feat: Feature4(git clone) BE - 3

### DIFF
--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -364,6 +364,7 @@ const clonePrivateRepo = async (req, res, user) => {
     const isIdInConfigFile = configData.match(userId);
 
     if (isIdInConfigFile) {
+      console.log(`There is id in config file! ${isIdInConfigFile}`);
       const tokenRegex = /token\s*=\s*(.+)/;
       const tokenMatch = configData.match(tokenRegex);
       const token = tokenMatch && tokenMatch.length >= 2 ? tokenMatch[1] : null;

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -491,4 +491,5 @@ export {
   handleMergeRequest,
   handleCloneRequest,
   clonePublicRepo,
+  clonePrivateRepo,
 };

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -12,7 +12,6 @@ import {
 import { simpleGit } from "simple-git";
 import fs from "fs";
 import os from "os";
-import { match } from "assert";
 
 const options = {
   baseDir: process.cwd(),
@@ -376,7 +375,7 @@ const clonePrivateUsingConfig = async (req, res, user) => {
     });
   } 
   catch (error) {
-      console.log(`Error[clonePrivateRepoAPI]: ${error}`);
+      console.log(`Error[clonePrivateUsingConfig]: ${error}`);
       res.status(500).json({
         type: "error",
         msg: `Failed to clone using config file, '${remoteAddress}'`,
@@ -476,7 +475,7 @@ export {
   showAllLocalBranches,
   handleMergeRequest,
   clonePublicRepo,
-  clonePrivateRepo,
+  // clonePrivateRepo,
   checkIdPrivateRepo,
   clonePrivateUsingConfig,
   clonePrivateWithoutConfig,

--- a/src/controllers/apiController.js
+++ b/src/controllers/apiController.js
@@ -285,21 +285,6 @@ const saveUserIdAndTokenToConfig = (userId, token) => {
   fs.writeFileSync(configPath, updatedConfigData, "utf8");
 };
 
-const checkIsGitRepo = async (req, res, user) => {
-  try {
-    gitHelper.cwd(path);
-    const isGitRepo = await gitHelper.checkIsRepo();
-    res.status(200).json({ isGitRepo });
-  } catch (error) {
-    console.log(`Error[checkIsGitRepoAPI]: ${error}`);
-    res.status(500).json({
-      type: "error",
-      msg: "Failed to check whether this is a git repo.",
-      error: error.message,
-    });
-  }
-};
-
 const clonePublicRepo = async (req, res, user) => {
   const remoteAddress = req.body.remoteAddress;
   try {
@@ -412,54 +397,6 @@ const clonePrivateWithoutConfig = async (req, res, user) => {
   }
 };
 
-// const clonePrivateRepo = async (req, res, user) => {
-//   const remoteAddress = req.body.remoteAddress;
-
-//   const urlData = remoteAddress.split("/");
-//   const IdInUrl = urlData[3];
-//   const repoNameInUrl = urlData[4];
-
-//   try {
-//     gitHelper.cwd(user.path);
-//     const configPath = `${os.homedir()}/.gitconfig`;
-//     const configData = fs.readFileSync(configPath, "utf8");
-//     const isIdInConfigFile = configData.match(IdInUrl);
-
-//     if (isIdInConfigFile) {
-//       // 분기점으로 잘 들어오는 것을 확인함
-//       console.log(`There is id in config file! ${isIdInConfigFile}`);
-//       const tokenRegex = /token\s*=\s*(.+)/;
-//       const tokenMatch = configData.match(tokenRegex);
-//       const token = tokenMatch && tokenMatch.length >= 2 ? tokenMatch[1] : null;
-//       console.log(`token: ${token}`);
-
-//       const privateRemoteAddress = `https://${token}:x-oauth-basic@github.com/${IdInUrl}/${repoNameInUrl}`;
-//       await gitHelper.clone(privateRemoteAddress, user.path);
-//     } else {
-//       const newPrivateId = req.body.newPrivateId;
-//       const newPrivateToken = req.body.newPrivateToken;
-//       const newPrivateRemoteAddress = `https://${newPrivateToken}:x-oauth-basic@github.com/${newPrivateId}/${repoNameInUrl}`;
-//       console.log(`${newPrivateRemoteAddress}`);
-//       await gitHelper.clone(newPrivateRemoteAddress, user.path);
-
-//       // config에 새 id, token을 저장.
-//       saveUserIdAndTokenToConfig(newPrivateId, newPrivateToken);
-//     }
-
-//     res.status(200).json({
-//       type: "success",
-//       msg: `Successfully cloned from '${remoteAddress}'`,
-//     });
-//   } catch (error) {
-//     console.log(`Error[clonePrivateRepoAPI]: ${error}`);
-//     res.status(500).json({
-//       type: "error",
-//       msg: `Failed to clone from '${remoteAddress}'`,
-//       error: error.message,
-//     });
-//   }
-// };
-
 export {
   checkRepo,
   checkStatus,
@@ -475,7 +412,6 @@ export {
   showAllLocalBranches,
   handleMergeRequest,
   clonePublicRepo,
-  // clonePrivateRepo,
   checkIdPrivateRepo,
   clonePrivateUsingConfig,
   clonePrivateWithoutConfig,

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -15,6 +15,8 @@ import {
   handleMergeRequest,
   clonePublicRepo,
   clonePrivateRepo,
+  clonePrivateUsingConfig,
+  clonePrivateWithoutConfig,
 } from "../controllers/apiController.js";
 
 const router = Router();

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -14,6 +14,7 @@ import {
   showAllLocalBranches,
   handleMergeRequest,
   handleCloneRequest,
+  clonePublicRepo,
 } from "../controllers/apiController.js";
 
 const router = Router();
@@ -27,6 +28,9 @@ export function apiRouterWrapper(user) {
   router.post("/merge", (req, res) => handleMergeRequest(req, res, user));
 
   router.post("/clone", (req, res) => handleCloneRequest(req, res, user));
+
+  // public repo를 체크할 때
+  router.post("/clone/public", (req, res) => clonePublicRepo(req, res, user));
 
   router.get("/isRepo", (req, res) => checkRepo(req, res, user));
 

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -15,6 +15,7 @@ import {
   handleMergeRequest,
   handleCloneRequest,
   clonePublicRepo,
+  clonePrivateRepo,
 } from "../controllers/apiController.js";
 
 const router = Router();
@@ -29,8 +30,11 @@ export function apiRouterWrapper(user) {
 
   router.post("/clone", (req, res) => handleCloneRequest(req, res, user));
 
-  // public repo를 체크할 때
+  // public repo 클론
   router.post("/clone/public", (req, res) => clonePublicRepo(req, res, user));
+
+  // private repo 클론
+  router.post("/clone/private", (req, res) => clonePrivateRepo(req, res, user));
 
   router.get("/isRepo", (req, res) => checkRepo(req, res, user));
 

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -13,7 +13,6 @@ import {
   handleBranchRequest,
   showAllLocalBranches,
   handleMergeRequest,
-  // handleCloneRequest,
   clonePublicRepo,
   clonePrivateRepo,
 } from "../controllers/apiController.js";
@@ -28,11 +27,8 @@ export function apiRouterWrapper(user) {
 
   router.post("/merge", (req, res) => handleMergeRequest(req, res, user));
 
-  // router.post("/clone", (req, res) => handleCloneRequest(req, res, user));
-
   // public repo 클론
   router.post("/clone/public", (req, res) => clonePublicRepo(req, res, user));
-
   // private repo 클론
   router.post("/clone/private", (req, res) => clonePrivateRepo(req, res, user));
 

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -13,7 +13,7 @@ import {
   handleBranchRequest,
   showAllLocalBranches,
   handleMergeRequest,
-  handleCloneRequest,
+  // handleCloneRequest,
   clonePublicRepo,
   clonePrivateRepo,
 } from "../controllers/apiController.js";
@@ -28,7 +28,7 @@ export function apiRouterWrapper(user) {
 
   router.post("/merge", (req, res) => handleMergeRequest(req, res, user));
 
-  router.post("/clone", (req, res) => handleCloneRequest(req, res, user));
+  // router.post("/clone", (req, res) => handleCloneRequest(req, res, user));
 
   // public repo 클론
   router.post("/clone/public", (req, res) => clonePublicRepo(req, res, user));

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -14,7 +14,6 @@ import {
   showAllLocalBranches,
   handleMergeRequest,
   clonePublicRepo,
-  clonePrivateRepo,
   clonePrivateUsingConfig,
   clonePrivateWithoutConfig,
   checkIdPrivateRepo,
@@ -35,7 +34,7 @@ export function apiRouterWrapper(user) {
 
   // private config에서 정보 탐색
   router.post("/clone/private/id", (req, res) => checkIdPrivateRepo(req, res, user));
-  
+
   // config에 정보 있을 때 클론
   router.post("/clone/private/config", (req, res) => clonePrivateUsingConfig(req, res, user));
 

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -17,6 +17,7 @@ import {
   clonePrivateRepo,
   clonePrivateUsingConfig,
   clonePrivateWithoutConfig,
+  checkIdPrivateRepo,
 } from "../controllers/apiController.js";
 
 const router = Router();
@@ -31,8 +32,12 @@ export function apiRouterWrapper(user) {
 
   // public repo 클론
   router.post("/clone/public", (req, res) => clonePublicRepo(req, res, user));
-  // private repo 클론
-  router.post("/clone/private", (req, res) => clonePrivateRepo(req, res, user));
+
+  // config에 정보 있을 때 클론
+  router.post("/clone/private/config", (req, res) => clonePrivateUsingConfig(req, res, user));
+
+  // config에 정보 없을 때 클론
+  router.post("/clone/private/new", (req, res) => clonePrivateWithoutConfig(req, res, user));
 
   router.get("/isRepo", (req, res) => checkRepo(req, res, user));
 

--- a/src/router/api.js
+++ b/src/router/api.js
@@ -33,6 +33,9 @@ export function apiRouterWrapper(user) {
   // public repo 클론
   router.post("/clone/public", (req, res) => clonePublicRepo(req, res, user));
 
+  // private config에서 정보 탐색
+  router.post("/clone/private/id", (req, res) => checkIdPrivateRepo(req, res, user));
+  
   // config에 정보 있을 때 클론
   router.post("/clone/private/config", (req, res) => clonePrivateUsingConfig(req, res, user));
 


### PR DESCRIPTION
## 작업 내용
- #41, #42  을 디벨롭하여 feature4 be 기능 구현 완료.

## 리뷰 내용
- 총 4개의 api를 전달하고 있음. (  clonePublicRepo, clonePrivateUsingConfig, clonePrivateWithoutConfig, checkIdPrivateRepo)
    - clonePublicRepo: 공개 레포의 경우 가장 기본적인 처리로 clone함. 
    - checkIdPrivateRepo: global config 파일을 탐색하여 github repo url에서 파싱한 user id가 config에 있는지 판단.
        - 200: id 존재
        - 203: id 없음
        - 500: 처리 중 오류
    - clonePrivateUsingConfig: config에서 추출하여 인증. 위의 200(id 존재)일 때 해당.
    - clonePrivateWithoutConfig: 새로운 req.body 값으로 인증. 위의 203(id 없음일 때 해당. 
- clonePrivateWithoutConfig일 때 새로 받은 id, token 값을 config에 저장하는 로직도 구현되어 있어 이 부분은 신경 안 써도 됨. 
```
const saveUserIdAndTokenToConfig = (userId, token) => {

  const configPath = `${os.homedir()}/.gitconfig`;

  const configData = fs.readFileSync(configPath, "utf8");

  const updatedConfigData =
    configData + `\n\n[github]\n  user = ${userId}\n  token = ${token}\n`;

  fs.writeFileSync(configPath, updatedConfigData, "utf8");
};
```
## 참고 사진

- public

<img width="1396" alt="public-clone" src="https://github.com/OSS-FILEBROWSER/pretty-git/assets/96538554/52d7b2fc-30cf-40f0-802b-52f0f9619454">

- private config check(203)

<img width="1156" alt="id203" src="https://github.com/OSS-FILEBROWSER/pretty-git/assets/96538554/16eea3e6-e89f-47d1-a81e-28f224e53ff0">

- private config check(200)

<img width="1159" alt="id200" src="https://github.com/OSS-FILEBROWSER/pretty-git/assets/96538554/ad5baa53-209b-4eb6-a962-4b7396af2577">

- private new

<img width="1156" alt="private-new" src="https://github.com/OSS-FILEBROWSER/pretty-git/assets/96538554/063fdf99-d10a-4783-8fb1-3f73fb744ecb">

- private config

<img width="1154" alt="private-config" src="https://github.com/OSS-FILEBROWSER/pretty-git/assets/96538554/36c65ddc-47dc-49bf-9d5d-349c8838474a">


